### PR TITLE
Migration to steamodded 1.x.x

### DIFF
--- a/StickersAlwaysShown.lua
+++ b/StickersAlwaysShown.lua
@@ -7,31 +7,29 @@
 ----------------------------------------------
 ------------MOD CODE -------------------------
 
-function SMODS.INIT.StickersAlwaysShown()
-    --- Enable achivements, you can comment it if you dont want them.
-    G.F_NO_ACHIEVEMENTS = false
-end
+--- Enable achivements, you can comment it if you dont want them.
+G.F_NO_ACHIEVEMENTS = false
 
 local CardDrawRef = Card.draw
 function Card:draw(layer)
-    if(self.ability.set == 'Joker' and G.STAGE == 2 ) then
-        if(self.facing == 'front') then
+    if (self.ability.set == 'Joker' and G.STAGE == 2) then
+        if (self.facing == 'front') then
             self.sticker = GetSticker(self)
         end
-        if(self.facing == 'back') then
+        if (self.facing == 'back') then
             self.sticker = nil
         end
     end
     local t = CardDrawRef(self, layer)
-   
-    return(t)
+
+    return (t)
 end
 
 function GetSticker(card)
-    if(card.sticker) then return card.sticker end
-        local center = GetCenterKeyByJokerName(card.ability.name)
-        local sticker = get_joker_win_sticker(center)
-        return sticker
+    if (card.sticker) then return card.sticker end
+    local center = GetCenterKeyByJokerName(card.ability.name)
+    local sticker = get_joker_win_sticker(center)
+    return sticker
 end
 
 function GetCenterKeyByJokerName(name)
@@ -45,3 +43,4 @@ end
 
 ----------------------------------------------
 ------------MOD CODE END----------------------
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,7 @@
 {
-    "name": "StickersAlwaysShown",
-    "version_number": "1.2.1",
-    "website_url": "https://github.com/SirMaiquis/Balatro-Stickers-Always-Shown",
-    "description": "The jokers stickers are always shown!",
-    "dependencies": [
-        "Steamopollys-Steamodded-0.9.5"
-    ]
+  "name": "StickersAlwaysShown",
+  "version_number": "1.2.1",
+  "website_url": "https://github.com/SirMaiquis/Balatro-Stickers-Always-Shown",
+  "description": "The jokers stickers are always shown!",
+  "dependencies": ["Steamopollys-Steamodded-0.9.8"]
 }


### PR DESCRIPTION
Hi. According Steamodded's wiki, SMODS.INIT is no longer needed to be called, leaving the SMODS.INIT function code as top level code. In fact, it does not load as it's marked as warning.

I apologize if I screwed it up with the manifest, I just landed in this Balatro mods' field.

Thanks.